### PR TITLE
Improve spotify search queries

### DIFF
--- a/paradify.net/pcore/pcore/pcore.web/Helper.cs
+++ b/paradify.net/pcore/pcore/pcore.web/Helper.cs
@@ -2,7 +2,7 @@
 {
     public class Helper
     {
-        static string[] wordsToRemove = new string[] { "feat", "-", "&", " x " };
+        static string[] wordsToRemove = new string[] { " feat ", " feat. ", " ft ", " ft. ", "&", " x " };
 
         public static string SetSearchReturnUrl(string controllerName, string searhQuery)
         {
@@ -13,7 +13,7 @@
         {
             foreach (string word in wordsToRemove)
             {
-                searhQuery = searhQuery.ToLower().Replace(word, "");
+                searhQuery = searhQuery.ToLower().Replace(word, " ");
             }
 
             return searhQuery;


### PR DESCRIPTION
Replacing with "" is bad, because words might just join: `word x word -> wordword`
Spaces and "-"'s are safe to ignore: spotify handles them well.
Feat is a abbreviation for "featuring" so i added 4 most popular cases for it.
**UPD**: and using "feat" without spaces might break songs, like "feather", "feature", etc